### PR TITLE
The Topic type is now deprecated

### DIFF
--- a/collective/plonetruegallery/profiles/default/types.xml
+++ b/collective/plonetruegallery/profiles/default/types.xml
@@ -3,6 +3,6 @@
         meta_type="Plone Types Tool">
 
     <object name="Folder"/>
-    <object name="Topic"/>
+    <object name="Topic" deprecated="True"/>
 
 </object>

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+3.4.0 (unreleased)
+------------------
+
+- The Topic type is now deprecated
+  [ale-rt]
+
 3.3.2 (2013-07-05)
 ------------------
 


### PR DESCRIPTION
If you do not have the Topic type registered in portal_types 
you will get the following error without this patch:

```
2013-12-31 16:36:57 ERROR Zope.SiteErrorLog 1388504217.830.896048646794 http://localhost:8080/Plone/portal_quickinstaller/reinstallProducts
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module <string>, line 6, in reinstallProducts
  Module AccessControl.requestmethod, line 70, in _curried
  Module Products.CMFQuickInstallerTool.QuickInstallerTool, line 640, in reinstallProducts
  Module Products.CMFQuickInstallerTool.QuickInstallerTool, line 580, in installProducts
  Module Products.CMFQuickInstallerTool.QuickInstallerTool, line 512, in installProduct
   - __traceback_info__: ('tede.meta',)
  Module Products.GenericSetup.tool, line 350, in runAllImportStepsFromProfile
   - __traceback_info__: profile-tede.meta:default
  Module Products.GenericSetup.tool, line 1100, in _runImportStepsFromContext
  Module Products.GenericSetup.tool, line 1015, in _doRunImportStep
   - __traceback_info__: typeinfo
  Module Products.CMFCore.exportimport.typeinfo, line 225, in importTypesTool
  Module Products.GenericSetup.utils, line 834, in importObjects
   - __traceback_info__: portal_types
  Module Products.GenericSetup.utils, line 509, in _importBody
  Module Products.CMFCore.exportimport.typeinfo, line 210, in _importNode
  Module Products.GenericSetup.utils, line 570, in _initObjects
   - __traceback_info__: ('Topic', '')
ValueError: unknown meta_type ''
```
