### PR TITLE
bugfix: exclude our own sizes when building the size vocabulary

### DIFF
--- a/collective/plonetruegallery/tests/test_various.py
+++ b/collective/plonetruegallery/tests/test_various.py
@@ -7,6 +7,7 @@ from collective.ptg.galleria import IGalleriaDisplaySettings
 from collective.plonetruegallery.tests import BaseTest
 from collective.plonetruegallery.utils import getGalleryAdapter, \
     getDisplayAdapter
+from collective.plonetruegallery.vocabularies import SizeVocabulary
 
 import unittest2 as unittest
 
@@ -76,6 +77,15 @@ class TestPloneAppImagingIntegration(BaseTest):
             self.assertEqual(adapter.sizes['medium']['height'], 576)
             self.assertEqual(adapter.sizes['large']['width'], 768)
             self.assertEqual(adapter.sizes['large']['height'], 768)
+
+    def test_size_vocabulary_with_extra_allowed_sizes(self):
+        props = getUtility(IPropertiesTool)
+        imaging_properties = props.get('imaging_properties', None)
+        if imaging_properties:
+            imaging_properties.manage_changeProperties(
+                allowed_sizes=['small 23:23', 'medium 42:42', 'big 91:91'])
+        self.assertEqual(SizeVocabulary(None).by_token.keys(),
+            ['small', 'large', 'medium', 'big'])
 
 
 def test_suite():

--- a/collective/plonetruegallery/vocabularies.py
+++ b/collective/plonetruegallery/vocabularies.py
@@ -86,7 +86,7 @@ def SizeVocabulary(context):
                 'allowed_sizes')
                 terms = [SimpleTerm(value=format_size(pair),
                             token=format_size(pair),
-                                title=pair) for pair in sizes if not format_size(pair) in ['icon', 'tile', 'listing', 'mini', 'preview', 'thumb', 'large']]
+                                title=pair) for pair in sizes if not format_size(pair) in ['icon', 'tile', 'listing', 'mini', 'preview', 'thumb', 'large', 'small', 'medium']]
                 image_terms =image_terms + terms
         
         return SimpleVocabulary(image_terms)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+3.4.4 (unreleased)
+------------------
+
+- Exclude our own sizes when building the size vocabulary.
+  [witsch]
+
+
 3.4.3 (2014-05-12)
 ------------------
 


### PR DESCRIPTION
this fixes the size vocabulary in case one defines a custom "small" or "medium" size
