### PR TITLE
Optional random lead

### DIFF
--- a/collective/plonetruegallery/browser/views/templates/subgallery.pt
+++ b/collective/plonetruegallery/browser/views/templates/subgallery.pt
@@ -25,7 +25,7 @@
   <ul id="subgallery-galleries">
     <tal:galleries tal:repeat="gallery view/subgalleries">
       <li class="gallery" tal:define="adapted python:view.getAdaptedGallery(gallery.getObject());
-                                       image adapted/get_random_image">
+                                       image python:adapted.get_random_image() if view.settings.random_subgallery_lead else adapted.get_first_image()">
         <a tal:attributes="href gallery/getURL">
           <img tal:condition="image" tal:attributes="src image/thumb_url" />
           <p tal:content="gallery/Title" />

--- a/collective/plonetruegallery/galleryadapters/base.py
+++ b/collective/plonetruegallery/galleryadapters/base.py
@@ -95,6 +95,12 @@ class BaseAdapter(object):
         else:
             return {}
 
+    def get_first_image(self):
+        if len(self.cooked_images) > 0:
+            return self.cooked_images[0]
+        else:
+            return {}
+
     @property
     def number_of_images(self):
         return len(self.cooked_images)

--- a/collective/plonetruegallery/interfaces.py
+++ b/collective/plonetruegallery/interfaces.py
@@ -31,6 +31,12 @@ class IGalleryAdapter(Interface):
         returns an empty dict if the gallery is empty.
         """
 
+    def get_first_image():
+        """
+        returns the first image with data.
+        returns an empty dict if the gallery is empty.
+        """
+
     def log_error():
         """
         provides an easy way to log errors in gallery adapters.
@@ -189,6 +195,13 @@ class IGallerySettings(Interface):
         description=_(u"description_show_subgalleries",
             default=u"If you select this option, previews for all "
                     u"nested galleries will show up below this gallery."
+        ),
+        default=True)
+    random_subgallery_lead = schema.Bool(
+        title=_(u"label_random_subgallery_lead", default=u"Show random lead image for subgalleries?"),
+        description=_(u"desciption_random_subgallery_lead",
+            default=u"If you select this option, the lead images for the subgalleries will be chosen at random. "
+                u"Otherwise the first image is chosen."
         ),
         default=True)
     batch_size = schema.Int(

--- a/collective/plonetruegallery/locales/collective.plonetruegallery.pot
+++ b/collective/plonetruegallery/locales/collective.plonetruegallery.pot
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Truegallery VERSION\n"
-"POT-Creation-Date: 2016-04-15 15:29+0000\n"
+"POT-Creation-Date: 2016-04-18 13:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -38,6 +38,11 @@ msgstr ""
 
 #: ./profiles.zcml:12
 msgid "Extension profile for the \"collective.plonetruegallery\" Plone product."
+msgstr ""
+
+#. Default: "Gallery Settings"
+#: portal Actions
+msgid "Gallery Settings"
 msgstr ""
 
 #: ./browser/views/configure.zcml:65
@@ -81,33 +86,38 @@ msgstr ""
 msgid "collective.plonetruegallery Upgrade to 0.8 profile"
 msgstr ""
 
+#. Default: "If you select this option, the lead images for the subgalleries will be chosen at random. Otherwise the first image is chosen."
+#: ./interfaces.py:202
+msgid "desciption_random_subgallery_lead"
+msgstr ""
+
 #. Default: "The amount of images shown in one page. This is not used for all display types."
-#: ./interfaces.py:196
+#: ./interfaces.py:209
 msgid "description_batch_size"
 msgstr ""
 
 #. Default: "This is only used for customized templates to show body text"
-#: ./interfaces.py:204
+#: ./interfaces.py:217
 msgid "description_bodytext"
 msgstr ""
 
 #. Default: "Should copyright notices be attached to each image?"
-#: ./interfaces.py:166
+#: ./interfaces.py:172
 msgid "description_copyright"
 msgstr ""
 
 #. Default: "Relative path from the root of the site where the stylesheet will be referenced from. This will be included after the display gallery type's styles and is a good entry point for customization."
-#: ./interfaces.py:210
+#: ./interfaces.py:223
 msgid "description_custom_stylesheet"
 msgstr ""
 
 #. Default: "If slide show is timed, the delay sets how long before the next image is shown in miliseconds."
-#: ./interfaces.py:173
+#: ./interfaces.py:179
 msgid "description_delay"
 msgstr ""
 
 #. Default: "The amount of time the change effect should take in miliseconds."
-#: ./interfaces.py:181
+#: ./interfaces.py:187
 msgid "description_fade_in_duration"
 msgstr ""
 
@@ -117,27 +127,27 @@ msgid "description_gallery_settings_form"
 msgstr ""
 
 #. Default: "The actual sizes used can vary depending on the gallery type that is used since different services have different size constraints. Only 'Small, Medium and Large' work with Flickr and Picasa"
-#: ./interfaces.py:139
+#: ./interfaces.py:145
 msgid "description_gallery_size"
 msgstr ""
 
 #. Default: "Select the type of gallery you want this to be.  If you select something other than default, you must fill out the information in the corresponding tab for that gallery type."
-#: ./interfaces.py:118
+#: ./interfaces.py:124
 msgid "description_gallery_type"
 msgstr ""
 
 #. Default: "If you select this option, previews for all nested galleries will show up below this gallery."
-#: ./interfaces.py:189
+#: ./interfaces.py:195
 msgid "description_show_subgalleries"
 msgstr ""
 
 #. Default: "The size of thumbnail images. Will only work with plone image gallery type."
-#: ./interfaces.py:149
+#: ./interfaces.py:155
 msgid "description_thumb_size"
 msgstr ""
 
 #. Default: "Should this gallery automatically change images for the user?"
-#: ./interfaces.py:159
+#: ./interfaces.py:165
 msgid "description_timed"
 msgstr ""
 
@@ -242,17 +252,17 @@ msgid "label_base_gallery_type"
 msgstr ""
 
 #. Default: "Batch Size"
-#: ./interfaces.py:195
+#: ./interfaces.py:208
 msgid "label_batch_size"
 msgstr ""
 
 #. Default: "Copyright notice?"
-#: ./interfaces.py:165
+#: ./interfaces.py:171
 msgid "label_copyright"
 msgstr ""
 
 #. Default: "Custom stylesheet"
-#: ./interfaces.py:209
+#: ./interfaces.py:222
 msgid "label_custom_stylesheet"
 msgstr ""
 
@@ -262,37 +272,37 @@ msgid "label_default_gallery_type"
 msgstr ""
 
 #. Default: "Delay"
-#: ./interfaces.py:172
+#: ./interfaces.py:178
 msgid "label_delay"
 msgstr ""
 
 #. Default: "Enable bodytext"
-#: ./interfaces.py:203
+#: ./interfaces.py:216
 msgid "label_enable_bodytext"
 msgstr ""
 
 #. Default: "Gallery Display Type"
-#: ./interfaces.py:126
+#: ./interfaces.py:132
 msgid "label_gallery_display_type"
 msgstr ""
 
 #. Default: "Choose the method in which the gallery should be displayed"
-#: ./interfaces.py:128
+#: ./interfaces.py:134
 msgid "label_gallery_display_type_description"
 msgstr ""
 
 #. Default: "Size"
-#: ./interfaces.py:138
+#: ./interfaces.py:144
 msgid "label_gallery_size"
 msgstr ""
 
 #. Default: "Type"
-#: ./interfaces.py:117
+#: ./interfaces.py:123
 msgid "label_gallery_type"
 msgstr ""
 
 #. Default: "Change Duration"
-#: ./interfaces.py:180
+#: ./interfaces.py:186
 msgid "label_image_change_duration"
 msgstr ""
 
@@ -312,8 +322,13 @@ msgstr ""
 msgid "label_preview"
 msgstr ""
 
+#. Default: "Show random lead image for subgalleries?"
+#: ./interfaces.py:201
+msgid "label_random_subgallery_lead"
+msgstr ""
+
 #. Default: "Show Sub-Galleries?"
-#: ./interfaces.py:188
+#: ./interfaces.py:194
 msgid "label_show_subgalleries"
 msgstr ""
 
@@ -338,7 +353,7 @@ msgid "label_thumb"
 msgstr ""
 
 #. Default: "Thumbnail image size"
-#: ./interfaces.py:148
+#: ./interfaces.py:154
 msgid "label_thumb_size"
 msgstr ""
 
@@ -348,7 +363,7 @@ msgid "label_tile"
 msgstr ""
 
 #. Default: "Timed?"
-#: ./interfaces.py:158
+#: ./interfaces.py:164
 msgid "label_timed"
 msgstr ""
 

--- a/collective/plonetruegallery/locales/manual.pot
+++ b/collective/plonetruegallery/locales/manual.pot
@@ -16,9 +16,7 @@ msgstr ""
 "Domain: collective.plonetruegallery\n"
 
 
-#. Default: "Gallery View"
-#: ./browser/views/configure.zcml
-msgid "Gallery View"
+#. Default: "Gallery Settings"
+#: portal Actions
+msgid "Gallery Settings"
 msgstr ""
-
-

--- a/collective/plonetruegallery/locales/nl/LC_MESSAGES/collective.plonetruegallery.po
+++ b/collective/plonetruegallery/locales/nl/LC_MESSAGES/collective.plonetruegallery.po
@@ -1,9 +1,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.1\n"
-"POT-Creation-Date: 2016-04-15 15:29+0000\n"
+"POT-Creation-Date: 2016-04-18 13:38+0000\n"
 "PO-Revision-Date: 2010-03-18 15:01+0100\n"
-"Last-Translator: Martijn Schenk <martijn.schenk@fourdigits.nl>\n"
+"Last-Translator: Fred van Dijk <info@zestsoftware.nl>\n"
 "Language-Team: Rob Gietema <rob@fourdigits.nl>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -38,6 +38,11 @@ msgstr "Activeer Plone True Gallery ondersteuning"
 #: ./profiles.zcml:12
 msgid "Extension profile for the \"collective.plonetruegallery\" Plone product."
 msgstr ""
+
+#. Default: "Gallery Settings"
+#: portal Actions
+msgid "Gallery Settings"
+msgstr "Galerij instellingen"
 
 #. Default: "Gallery View"
 #: ./browser/views/configure.zcml:65
@@ -81,33 +86,38 @@ msgstr ""
 msgid "collective.plonetruegallery Upgrade to 0.8 profile"
 msgstr ""
 
+#. Default: "If you select this option, the lead images for the subgalleries will be chosen at random. Otherwise the first image is chosen."
+#: ./interfaces.py:202
+msgid "desciption_random_subgallery_lead"
+msgstr "Indien gekozen zal de hoofdafbeelding van elke subgalerij willekeurig worden gekozen per weergave. Anders wordt altijd de eerste afbeelding getoond."
+
 #. Default: "The amount of images shown in one page. This is not used for all display types."
-#: ./interfaces.py:196
+#: ./interfaces.py:209
 msgid "description_batch_size"
 msgstr "Het aantal afbeeldingen op één pagina. Optioneel voor sommige galerijweergaven"
 
 #. Default: "This is only used for customized templates to show body text"
-#: ./interfaces.py:204
+#: ./interfaces.py:217
 msgid "description_bodytext"
 msgstr "Alleen van toepassingen voor maatwerksjablonen waarin de hoofdtekst staat"
 
 #. Default: "Should copyright notices be attached to each image?"
-#: ./interfaces.py:166
+#: ./interfaces.py:172
 msgid "description_copyright"
 msgstr "Voeg een auteursrecht-notitie toe aan elke afbeelding"
 
 #. Default: "Relative path from the root of the site where the stylesheet will be referenced from. This will be included after the display gallery type's styles and is a good entry point for customization."
-#: ./interfaces.py:210
+#: ./interfaces.py:223
 msgid "description_custom_stylesheet"
 msgstr "Een relatief pad vanaf de hoofdmap van de website waarvandaan een css stylesheet kan worden geladen. Deze stylesheet wordt achter de galerijspecifieke css geplaatst en is een basis voor verdere stijlaanpassing."
 
 #. Default: "If slide show is timed, the delay sets how long before the next image is shown in miliseconds."
-#: ./interfaces.py:173
+#: ./interfaces.py:179
 msgid "description_delay"
 msgstr "Indien de slide show op tijd is ingesteld laat de vertraging zien hoe lang het duurt in miliseconden voordat de nieuwe afbeelding getoond zal worden."
 
 #. Default: "The amount of time the change effect should take in miliseconds."
-#: ./interfaces.py:181
+#: ./interfaces.py:187
 msgid "description_fade_in_duration"
 msgstr "De totale effect welke het schermwissel effect nodig heeft in miliseconden."
 
@@ -117,27 +127,27 @@ msgid "description_gallery_settings_form"
 msgstr "Wijzig de instellingen voor deze galerij."
 
 #. Default: "The actual sizes used can vary depending on the gallery type that is used since different services have different size constraints. Only 'Small, Medium and Large' work with Flickr and Picasa"
-#: ./interfaces.py:139
+#: ./interfaces.py:145
 msgid "description_gallery_size"
 msgstr "De werkelijke grootte hangt af van het galerijtype dat wordt ingesteld: sommige (externe) diensten hebben andere beperkingen. Voor Flickr en Picasa werkt alleen 'klein, middel en groot'."
 
 #. Default: "Select the type of gallery you want this to be.  If you select something other than default, you must fill out the information in the corresponding tab for that gallery type."
-#: ./interfaces.py:118
+#: ./interfaces.py:124
 msgid "description_gallery_type"
 msgstr "Selecteer het passende type galerij. Als u iets anders selecteert dan de standaard galerij moet u de informatie hiervoor in de corresponderende tab aanvullen"
 
 #. Default: "If you select this option, previews for all nested galleries will show up below this gallery."
-#: ./interfaces.py:189
+#: ./interfaces.py:195
 msgid "description_show_subgalleries"
 msgstr "Deze optie toont onderaan de galerijweergave voorvertoningen van geneste galerijen in dezelfde map."
 
 #. Default: "The size of thumbnail images. Will only work with plone image gallery type."
-#: ./interfaces.py:149
+#: ./interfaces.py:155
 msgid "description_thumb_size"
-msgstr ""De grootte van voorvertoning. Werkt alleen bij Plone fotogalerijen.
+msgstr "De grootte van voorvertoning. Werkt alleen bij Plone fotogalerijen."
 
 #. Default: "Should this gallery automatically change images for the user?"
-#: ./interfaces.py:159
+#: ./interfaces.py:165
 msgid "description_timed"
 msgstr "Moet deze galerij automatisch afbeeldingen wisselen/afspelen voor de gebruiker?"
 
@@ -242,58 +252,57 @@ msgid "label_base_gallery_type"
 msgstr "basis: Dit is geen gallery typ. Denk hier aan de abstracte versie..."
 
 #. Default: "Batch Size"
-#: ./interfaces.py:195
+#: ./interfaces.py:208
 msgid "label_batch_size"
 msgstr "seriegrootte"
 
 #. Default: "Copyright notice?"
-#: ./interfaces.py:165
+#: ./interfaces.py:171
 msgid "label_copyright"
 msgstr "Toon auteursrecht?"
 
 #. Default: "Custom stylesheet"
-#: ./interfaces.py:209
+#: ./interfaces.py:222
 msgid "label_custom_stylesheet"
 msgstr "Aangepaste css-stijlen"
 
 #. Default: "Use Plone To Manage Images"
 #: ./galleryadapters/basic.py:38
-#, fuzzy
 msgid "label_default_gallery_type"
-msgstr "standaard: Gebruik Plone om uw Afbeeldingen te Beheren"
+msgstr "Gebruik Plone om afbeeldingen te beheren"
 
 #. Default: "Delay"
-#: ./interfaces.py:172
+#: ./interfaces.py:178
 msgid "label_delay"
 msgstr "Vertraging"
 
 #. Default: "Enable bodytext"
-#: ./interfaces.py:203
+#: ./interfaces.py:216
 msgid "label_enable_bodytext"
 msgstr "Toon hoofdtekst"
 
 #. Default: "Gallery Display Type"
-#: ./interfaces.py:126
+#: ./interfaces.py:132
 msgid "label_gallery_display_type"
-msgstr "Gallery weergave type"
+msgstr "Galerij weergave"
 
 #. Default: "Choose the method in which the gallery should be displayed"
-#: ./interfaces.py:128
+#: ./interfaces.py:134
 msgid "label_gallery_display_type_description"
 msgstr "Kies de manier waarop de gallery weergegeven moet worden"
 
 #. Default: "Size"
-#: ./interfaces.py:138
+#: ./interfaces.py:144
 msgid "label_gallery_size"
 msgstr "Grootte"
 
 #. Default: "Type"
-#: ./interfaces.py:117
+#: ./interfaces.py:123
 msgid "label_gallery_type"
 msgstr "Type"
 
 #. Default: "Change Duration"
-#: ./interfaces.py:180
+#: ./interfaces.py:186
 msgid "label_image_change_duration"
 msgstr "Duur van de overgang van afbeeldingen"
 
@@ -306,17 +315,22 @@ msgstr "mini"
 #: ./browser/views/templates/layout.pt:23
 #: ./browser/views/templates/layout_p3.pt:40
 msgid "label_no_images_in_gallery"
-msgstr "Er bevinden zich geen afbeeldingen in deze gallery"
+msgstr "Er bevinden zich geen afbeeldingen in deze galerij."
 
 #. Default: "preview"
 #: ./vocabularies.py:109
 msgid "label_preview"
 msgstr "preview"
 
+#. Default: "Show random lead image for subgalleries?"
+#: ./interfaces.py:201
+msgid "label_random_subgallery_lead"
+msgstr "Toon willekeurige hoofdafbeelding voor subgalerijen?"
+
 #. Default: "Show Sub-Galleries?"
-#: ./interfaces.py:188
+#: ./interfaces.py:194
 msgid "label_show_subgalleries"
-msgstr "Toon sub-galerijen"
+msgstr "Toon sub-galerijen?"
 
 #. Default: "Large"
 #: ./vocabularies.py:77
@@ -339,7 +353,7 @@ msgid "label_thumb"
 msgstr "thumb"
 
 #. Default: "Thumbnail image size"
-#: ./interfaces.py:148
+#: ./interfaces.py:154
 msgid "label_thumb_size"
 msgstr "Afbeeldingsgrootte voorvertoning"
 
@@ -349,7 +363,7 @@ msgid "label_tile"
 msgstr "tile"
 
 #. Default: "Timed?"
-#: ./interfaces.py:158
+#: ./interfaces.py:164
 msgid "label_timed"
 msgstr "Getimed?"
 
@@ -360,7 +374,7 @@ msgstr "Er zijn geen wijzigingen in de galerij-instellingen."
 
 #: ./browser/views/templates/subgallery.pt:13
 msgid "or"
-msgstr "van"
+msgstr "of"
 
 #. Default: "Gallery Settings Saved."
 #: ./browser/views/settings.py:35

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 3.4.8 (unreleased)
 ------------------
 
+- Add option to disable the random lead image from galleries so that
+  always the first image is returned. Also useful with subgalleries.
+  [dveeze, fredvd]
+
 - Updated Dutch translations.
   [fredvd]
 
@@ -23,7 +27,7 @@ Changelog
 - Added dexterity folder to classes implementing IGallery to work with dexterity types and Plone 5.
   [sandrarum]
 
-- Updated portuguese pt-br translation. 
+- Updated portuguese pt-br translation.
   [lccruz]
 
 
@@ -856,4 +860,3 @@ Changelog
 .1 - Initial
 ------------
 * Initial release
-


### PR DESCRIPTION
Add option to disable the random lead image from galleries so that always the first image is returned. Also Useful with subgalleries.